### PR TITLE
Downgrade package to make it work on android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.4",
-        "@react-native-community/datetimepicker": "^8.3.0",
+        "@react-native-community/datetimepicker": "8.2.0",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.1.1",
         "@types/babel-traverse": "^6.25.10",
@@ -4269,9 +4269,9 @@
       }
     },
     "node_modules/@react-native-community/datetimepicker": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.3.0.tgz",
-      "integrity": "sha512-K/KgaJbLtjMpx4PaG4efrVIcSe6+DbLufeX1lwPB5YY8i3sq9dOh6WcAcMTLbaRTUpurebQTkl7puHPFm9GalA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.2.0.tgz",
+      "integrity": "sha512-qrUPhiBvKGuG9Y+vOqsc56RPFcHa1SU2qbAMT0hfGkoFIj3FodE0VuPVrEa8fgy7kcD5NQmkZIKgHOBLV0+hWg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.4",
-    "@react-native-community/datetimepicker": "^8.3.0",
+    "@react-native-community/datetimepicker": "8.2.0",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.1.1",
     "@types/babel-traverse": "^6.25.10",


### PR DESCRIPTION
Must run `npx expo install @react-native-community/datetimepicker`