### PR TITLE
Validate that user is logged in

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -26,5 +26,8 @@
       "**/.*",
       "**/node_modules/**"
     ]
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,18 +2,8 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-
-    // This rule allows anyone with your Firestore database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
     match /{document=**} {
-      allow read, write: if request.time > timestamp.date(2024, 12, 1);
+      allow read, write: if request.auth != null;
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}


### PR DESCRIPTION
Add basic firebase rules to only allow authenticated users to access storage and firestore. Note that *authentication* is **NOT** *validation* – we still aren't checking if the user should actually be allowed to do these things; these rules are a stop-gap measure.
