### PR TITLE
Use tunnel by default since it is usually necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start --tunnel",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo run:android",
     "ios": "expo run:ios",


### PR DESCRIPTION
Note that this means we can actually use `npm start` now instead of a longer, more complicated command.

Be sure to set `EXPO_TUNNEL_SUBDOMAIN` in the `.env` to something without hyphens.