### PR TITLE
Only attempt to avoid the dynamic island on iOS

### DIFF
--- a/src/styles/containers.js
+++ b/src/styles/containers.js
@@ -10,7 +10,10 @@ const containerStyles = StyleSheet.create({
   wrapper: {
     flex: 1,
     backgroundColor: '#FAFAFA',
-    paddingTop: vh * 10,
+    paddingTop: Platform.select({
+      ios: vh * 10, // avoid iOS Dynamic Island
+      default: 0,
+    }),
   },
   imageWrapper: {
     flexDirection: 'column',


### PR DESCRIPTION
This fixes the large padding gap at the top of the screen on android phones (though there may still be issues on older iOS devices; this may require more testing).